### PR TITLE
Add script for FanGraphs URL generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # xSTATx-v1.0
+
+This repository contains a simple utility script for constructing FanGraphs leaderboard URLs.
+
+## Usage
+
+Run `generate_fangraphs_url.py` with optional parameters to override defaults. The script will print the resulting URL.
+
+```bash
+python3 generate_fangraphs_url.py
+```
+
+You can customize the parameters by editing the `example` dictionary at the bottom of the script or by importing the `generate_url` function in your own code.

--- a/generate_fangraphs_url.py
+++ b/generate_fangraphs_url.py
@@ -1,0 +1,38 @@
+import urllib.parse
+
+BASE_URL = "https://www.fangraphs.com/leaders.aspx"
+
+# Default parameters for the leaderboard
+DEFAULT_PARAMS = {
+    "pos": "all",
+    "team": "0",
+    "stats": "bat",
+    "type": "0",
+    "season": "2025",
+    "month": "0",
+    "qual": "y",
+    "ind": "0",
+    "sortcol": "1",
+    "sortdir": "desc",
+}
+
+
+def generate_url(overrides=None):
+    """Generate a FanGraphs leaderboard URL with optional parameter overrides."""
+    params = DEFAULT_PARAMS.copy()
+    if overrides:
+        params.update({k: str(v) for k, v in overrides.items() if v is not None})
+    query = urllib.parse.urlencode(params)
+    return f"{BASE_URL}?{query}"
+
+
+if __name__ == "__main__":
+    # Example usage
+    example = {
+        "pos": "cf",
+        "team": "14",
+        "stats": "bat",
+        "type": "1",
+        "sortcol": "3",
+    }
+    print(generate_url(example))


### PR DESCRIPTION
## Summary
- add Python utility to build FanGraphs leaderboard URLs
- document usage in README

## Testing
- `python3 generate_fangraphs_url.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d0f0dc708332808c591c471022ce